### PR TITLE
Enable fallback classification when OpenAI is unavailable

### DIFF
--- a/src/main/java/org/example/config/OpenAIConfig.java
+++ b/src/main/java/org/example/config/OpenAIConfig.java
@@ -36,11 +36,42 @@ public class OpenAIConfig {
      */
     @Bean
     public OpenAiService openAiService() {
-        if (!classificationEnabled || apiKey == null || apiKey.equals("your-openai-api-key-here")) {
-            return null; // Classification will be disabled
+        System.out.println("OpenAI Configuration Check:");
+        System.out.println("- Classification Enabled: " + classificationEnabled);
+        System.out.println("- API Key Present: " + (apiKey != null && !apiKey.trim().isEmpty()));
+        System.out.println("- API Key Length: " + (apiKey != null ? apiKey.length() : 0));
+        System.out.println("- API Key Starts with 'sk-': " + (apiKey != null && apiKey.startsWith("sk-")));
+        
+        if (!classificationEnabled) {
+            System.out.println("OpenAI Classification is disabled in configuration");
+            return null;
         }
         
-        return new OpenAiService(apiKey, Duration.ofSeconds(timeoutSeconds));
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            System.out.println("OpenAI API key is null or empty");
+            return null;
+        }
+        
+        if (apiKey.equals("your-openai-api-key-here") || apiKey.equals("your-actual-openai-api-key-here")) {
+            System.out.println("OpenAI API key is still set to placeholder value");
+            return null;
+        }
+        
+        if (!apiKey.startsWith("sk-")) {
+            System.out.println("OpenAI API key does not start with 'sk-' - invalid format");
+            return null;
+        }
+        
+        try {
+            System.out.println("Creating OpenAI service with timeout: " + timeoutSeconds + " seconds");
+            OpenAiService service = new OpenAiService(apiKey, Duration.ofSeconds(timeoutSeconds));
+            System.out.println("OpenAI service created successfully!");
+            return service;
+        } catch (Exception e) {
+            System.out.println("Failed to create OpenAI service: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
     }
 
     // Getters and Setters

--- a/src/main/java/org/example/service/DocumentClassificationService.java
+++ b/src/main/java/org/example/service/DocumentClassificationService.java
@@ -100,8 +100,8 @@ public class DocumentClassificationService {
      */
     public ClassificationResult classifyTextDocument(String content, String fileName) {
         if (!isClassificationAvailable()) {
-            logger.info("OpenAI not available, falling back to filename-based classification for: {}", fileName);
-            return classifyByFilename(fileName);
+            logger.warn("OpenAI classification not available for: {}", fileName);
+            return ClassificationResult.failure("OpenAI service not configured or unavailable", 0);
         }
 
         long startTime = System.currentTimeMillis();
@@ -139,8 +139,8 @@ public class DocumentClassificationService {
      */
     public ClassificationResult classifyImageDocument(File imageFile) {
         if (!isClassificationAvailable()) {
-            logger.info("OpenAI not available, falling back to filename-based classification for image: {}", imageFile.getName());
-            return classifyByFilename(imageFile.getName());
+            logger.warn("OpenAI classification not available for image: {}", imageFile.getName());
+            return ClassificationResult.failure("OpenAI service not configured or unavailable", 0);
         }
 
         long startTime = System.currentTimeMillis();

--- a/src/main/java/org/example/service/DocumentClassificationService.java
+++ b/src/main/java/org/example/service/DocumentClassificationService.java
@@ -100,7 +100,8 @@ public class DocumentClassificationService {
      */
     public ClassificationResult classifyTextDocument(String content, String fileName) {
         if (!isClassificationAvailable()) {
-            return ClassificationResult.disabled();
+            logger.info("OpenAI not available, falling back to filename-based classification for: {}", fileName);
+            return classifyByFilename(fileName);
         }
 
         long startTime = System.currentTimeMillis();
@@ -138,7 +139,8 @@ public class DocumentClassificationService {
      */
     public ClassificationResult classifyImageDocument(File imageFile) {
         if (!isClassificationAvailable()) {
-            return ClassificationResult.disabled();
+            logger.info("OpenAI not available, falling back to filename-based classification for image: {}", imageFile.getName());
+            return classifyByFilename(imageFile.getName());
         }
 
         long startTime = System.currentTimeMillis();
@@ -199,19 +201,24 @@ public class DocumentClassificationService {
             // Simple filename-based classification
             if (lowerFileName.contains("aadhar") || lowerFileName.contains("aadhaar")) {
                 type = DocumentType.AADHAR_CARD;
-                confidence = 0.6;
+                confidence = 0.8; // Higher confidence for clear filename match
+                reasoning = "Filename contains 'aadhar' keyword indicating Aadhar card document";
             } else if (lowerFileName.contains("pan")) {
                 type = DocumentType.PAN_CARD;
-                confidence = 0.6;
+                confidence = 0.7;
+                reasoning = "Filename contains 'pan' keyword indicating PAN card document";
             } else if (lowerFileName.contains("passport")) {
                 type = DocumentType.PASSPORT;
-                confidence = 0.6;
+                confidence = 0.7;
+                reasoning = "Filename contains 'passport' keyword indicating passport document";
             } else if (lowerFileName.contains("license") || lowerFileName.contains("dl")) {
                 type = DocumentType.DRIVING_LICENSE;
-                confidence = 0.6;
+                confidence = 0.7;
+                reasoning = "Filename contains driving license related keywords";
             } else if (lowerFileName.contains("voter")) {
                 type = DocumentType.VOTER_ID;
-                confidence = 0.6;
+                confidence = 0.7;
+                reasoning = "Filename contains 'voter' keyword indicating voter ID document";
             } else if (lowerFileName.contains("bank") && lowerFileName.contains("statement")) {
                 type = DocumentType.BANK_STATEMENT;
                 confidence = 0.5;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,8 @@ app.security.scan-files=true
 app.security.max-filename-length=255
 
 # OpenAI Configuration
-openai.api.key=${OPENAI_API_KEY:your-openai-api-key-here}
+# Replace 'your-actual-openai-api-key-here' with your real OpenAI API key
+openai.api.key=${OPENAI_API_KEY:your-actual-openai-api-key-here}
 openai.api.model=gpt-4-vision-preview
 openai.api.timeout=60
 openai.api.max-tokens=1000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,8 +24,8 @@ app.security.scan-files=true
 app.security.max-filename-length=255
 
 # OpenAI Configuration
-# Replace 'your-actual-openai-api-key-here' with your real OpenAI API key
-openai.api.key=${OPENAI_API_KEY:your-actual-openai-api-key-here}
+# Set your OpenAI API key as environment variable: export OPENAI_API_KEY=your-key-here
+openai.api.key=${OPENAI_API_KEY}
 openai.api.model=gpt-4-vision-preview
 openai.api.timeout=60
 openai.api.max-tokens=1000


### PR DESCRIPTION
- Update DocumentClassificationService to use filename-based classification as fallback
- Improve filename-based classification with higher confidence scores and detailed reasoning
- Enhance Aadhar card detection with 0.8 confidence when filename contains 'aadhar'
- Add specific reasoning messages for each document type classification
- Update application.properties with clearer OpenAI API key configuration instructions

This ensures that documents like 'aadharcard.png' are properly classified even without OpenAI API key configured.