### PR TITLE
fix: Add missing hasPrivacyBudget method to VaultGemmaService

### DIFF
--- a/src/main/java/com/documentclassifier/service/VaultGemmaService.java
+++ b/src/main/java/com/documentclassifier/service/VaultGemmaService.java
@@ -169,7 +169,14 @@ public class VaultGemmaService {
     }
     
     /**
-     * Check if user has sufficient privacy budget
+     * Check if user has sufficient privacy budget (public method for integration)
+     */
+    public boolean hasPrivacyBudget(String userId) {
+        return checkPrivacyBudget(userId);
+    }
+    
+    /**
+     * Check if user has sufficient privacy budget (internal method)
      */
     private boolean checkPrivacyBudget(String userId) {
         double usedBudget = privacyBudgetTracker.getOrDefault(userId, 0.0);


### PR DESCRIPTION
- Add public hasPrivacyBudget(userId) method for VaultGemmaIntegration compatibility
- Keep existing private checkPrivacyBudget method for internal use
- Resolves compilation error in VaultGemmaIntegration.java